### PR TITLE
Loop node clean-up + fixes

### DIFF
--- a/nodes/mn_node_list.py
+++ b/nodes/mn_node_list.py
@@ -116,9 +116,7 @@ def getNodeNameDictionary():
 		("mn_ScriptNode", "Script") ] ))
 		
 	nodes.append(("System", [
-		("mn_LoopCallerNode", "Loop Caller"),
-		("mn_LoopStartNode", "Generic Loop", {"preset" : repr("NONE")}),
-		("mn_LoopStartNode", "Object Loop", {"preset" : repr("OBJECT")}),
+		("mn_LoopCallerNode", "Loop"),
 		("mn_GroupCaller", "Group Caller"),
 		("mn_GroupInput", "Group Input"),
 		("mn_GroupOutput", "Group Output"),

--- a/nodes/system/mn_loop_caller.py
+++ b/nodes/system/mn_loop_caller.py
@@ -19,20 +19,27 @@ class mn_LoopCallerNode(Node, AnimationNode):
 	
 	def getStartLoopNodeItems(self, context):
 		startLoopNames = getAttributesFromNodesWithType("mn_LoopStartNode", "loopName")
-		startLoopNames.sort()
-		startLoopNames.reverse()
+		
 		startLoopItems = []
 		for loopName in startLoopNames:
 			startLoopItems.append((loopName, loopName, ""))
-		if len(startLoopItems) == 0: startLoopItems.append(("NONE", "NONE", ""))
+
+		if len(startLoopItems) == 0: 
+			startLoopItems.append(("NONE", "NONE", ""))
 		return startLoopItems
 	
-	selectedLoop = bpy.props.EnumProperty(items = getStartLoopNodeItems, name = "Selected Loop")
+	def updateActiveL(self, context):
+		self.updateActiveLoop()
+
+	selectedLoop = bpy.props.EnumProperty(
+        items=getStartLoopNodeItems,
+        name="Selected Loop",
+        update=updateActiveL)
 	activeLoop = bpy.props.StringProperty(name = "Active Loop", default = "Loop")
 	
 	def init(self, context):
 		forbidCompiling()
-		self.updateSockets()
+		self.updateActiveLoop()
 		allowCompiling()
 		
 	def draw_buttons(self, context, layout):	
@@ -94,7 +101,8 @@ class mn_LoopCallerNode(Node, AnimationNode):
 		return getNodeFromTypeWithAttribute("mn_LoopStartNode", "loopName", self.activeLoop)
 		
 	def updateActiveLoop(self):
-		self.activeLoop = self.selectedLoop
+		if self.selectedLoop != "NONE":
+			self.activeLoop = self.selectedLoop
 		self.updateSockets()
 		nodeTreeChanged()
 


### PR DESCRIPTION
I compared the behaviour against your version. There is improvement, the sockets change automatically when you change the loop. **BUT** there is one bug in your version that I can't fix without screwing everything up. That is when you add a loopcaller from a startloop node. Generally activeloop and the loop selected in the enum don't match. But since this bug was already present, I am not introducing any new bugs (I think). 

Let me know if there is still something wrong :)