### PR TITLE
Added regexp based splitting in the Split text node

### DIFF
--- a/nodes/text/mn_split_text.py
+++ b/nodes/text/mn_split_text.py
@@ -18,7 +18,7 @@ class mn_SplitText(Node, AnimationNode):
 		self.setHideProperty()
 	
 	splitType = bpy.props.EnumProperty(name = "Split Type", default = "Regexp", items = splitTypes, update = splitTypeChanges)
-	keepDelimiters = bpy.props.BoolProperty(default=False)
+	keepDelimiters = bpy.props.BoolProperty(default = False)
 	
 	def init(self, context):
 		forbidCompiling()
@@ -30,7 +30,7 @@ class mn_SplitText(Node, AnimationNode):
 		
 	def draw_buttons(self, context, layout):
 		layout.prop(self, "splitType", text = "Type")
-		if self.splitType == "Regexp": layout.prop(self, "keepDelimiters", text="Keep Delimiters")
+		if self.splitType == "Regexp": layout.prop(self, "keepDelimiters", text = "Keep Delimiters")
 		
 	def setHideProperty(self):
 		self.inputs["Split By"].hide = not self.splitType == "Regexp"
@@ -53,7 +53,7 @@ class mn_SplitText(Node, AnimationNode):
 		elif self.splitType == "Regexp":
 			if splitBy == "": textList = [text]
 			else: 
-				if self.keepDelimiters == True: textList = re.split("("+splitBy+")", text)
+				if self.keepDelimiters: textList = re.split("("+splitBy+")", text)
 				else: textList = re.split(splitBy, text)
 
 		return textList, len(textList)

--- a/nodes/text/mn_split_text.py
+++ b/nodes/text/mn_split_text.py
@@ -8,7 +8,7 @@ splitTypes = [
 	("Characters", "Characters", ""),
 	("Words", "Words", ""),
 	("Lines", "Lines", ""),
-	("Custom", "Custom", "") ]
+	("Regexp", "Regexp", "") ]
 
 class mn_SplitText(Node, AnimationNode):
 	bl_idname = "mn_SplitText"
@@ -17,7 +17,7 @@ class mn_SplitText(Node, AnimationNode):
 	def splitTypeChanges(self, context):
 		self.setHideProperty()
 	
-	splitType = bpy.props.EnumProperty(name = "Split Type", default = "Custom", items = splitTypes, update = splitTypeChanges)
+	splitType = bpy.props.EnumProperty(name = "Split Type", default = "Regexp", items = splitTypes, update = splitTypeChanges)
 	
 	def init(self, context):
 		forbidCompiling()
@@ -31,7 +31,7 @@ class mn_SplitText(Node, AnimationNode):
 		layout.prop(self, "splitType", text = "Type")
 		
 	def setHideProperty(self):
-		self.inputs["Split By"].hide = not self.splitType == "Custom"
+		self.inputs["Split By"].hide = not self.splitType == "Regexp"
 		
 	def getInputSocketNames(self):
 		return {"Text" : "text",
@@ -42,11 +42,14 @@ class mn_SplitText(Node, AnimationNode):
 
 	def execute(self, text, splitBy):
 		textList = []
+
 		if self.splitType == "Characters": textList = list(text)
-		elif self.splitType == "Words": textList = text.split()
-		elif self.splitType == "Lines": textList = text.split("\n")
-		elif self.splitType == "Custom":
+		if self.splitType == "Words": textList = text.split()
+		if self.splitType == "Lines": textList = text.split("\n")
+
+		if self.splitType == "Regexp":
 			if splitBy == "": textList = list(text)
-			else: textList = text.split(splitBy)
+			else: textList = re.split(splitBy, text)
+
 		return textList, len(textList)
 

--- a/nodes/text/mn_split_text.py
+++ b/nodes/text/mn_split_text.py
@@ -47,10 +47,10 @@ class mn_SplitText(Node, AnimationNode):
 		textList = []
 
 		if self.splitType == "Characters": textList = list(text)
-		if self.splitType == "Words": textList = text.split()
-		if self.splitType == "Lines": textList = text.split("\n")
+		elif self.splitType == "Words": textList = text.split()
+		elif self.splitType == "Lines": textList = text.split("\n")
 
-		if self.splitType == "Regexp":
+		elif self.splitType == "Regexp":
 			if splitBy == "": textList = [text]
 			else: 
 				if self.keepDelimiters == True: textList = re.split("("+splitBy+")", text)

--- a/nodes/text/mn_split_text.py
+++ b/nodes/text/mn_split_text.py
@@ -18,6 +18,7 @@ class mn_SplitText(Node, AnimationNode):
 		self.setHideProperty()
 	
 	splitType = bpy.props.EnumProperty(name = "Split Type", default = "Regexp", items = splitTypes, update = splitTypeChanges)
+	keepDelimiters = bpy.props.BoolProperty(default=False)
 	
 	def init(self, context):
 		forbidCompiling()
@@ -29,9 +30,11 @@ class mn_SplitText(Node, AnimationNode):
 		
 	def draw_buttons(self, context, layout):
 		layout.prop(self, "splitType", text = "Type")
+		if self.splitType == "Regexp": layout.prop(self, "keepDelimiters", text="Keep Delimiters")
 		
 	def setHideProperty(self):
 		self.inputs["Split By"].hide = not self.splitType == "Regexp"
+
 		
 	def getInputSocketNames(self):
 		return {"Text" : "text",
@@ -49,7 +52,9 @@ class mn_SplitText(Node, AnimationNode):
 
 		if self.splitType == "Regexp":
 			if splitBy == "": textList = list(text)
-			else: textList = re.split(splitBy, text)
+			else: 
+				if self.keepDelimiters == True: textList = re.split("("+splitBy+")", text)
+				else: textList = re.split(splitBy, text)
 
 		return textList, len(textList)
 

--- a/nodes/text/mn_split_text.py
+++ b/nodes/text/mn_split_text.py
@@ -51,7 +51,7 @@ class mn_SplitText(Node, AnimationNode):
 		if self.splitType == "Lines": textList = text.split("\n")
 
 		if self.splitType == "Regexp":
-			if splitBy == "": textList = list(text)
+			if splitBy == "": textList = [text]
 			else: 
 				if self.keepDelimiters == True: textList = re.split("("+splitBy+")", text)
 				else: textList = re.split(splitBy, text)


### PR DESCRIPTION
In the **split text** node I changed the Custom mode to Regexp mode.

Instead of splitting by plain string comparison the split is now regexp based. In the "split by" the user can input a regexp. 

I also added a checkbox to keep the delimiters in the list. 
**Example:** ```Dummy text``` split at "**u**" 

- without the option checked would give ```["D","mmy text"]```
- with the option checked gives ```["D","u","mmy text"]```

This feature was requested here #95 